### PR TITLE
Update Merge-MailboxFolder.ps1

### DIFF
--- a/Legacy/Merge-MailboxFolder.ps1
+++ b/Legacy/Merge-MailboxFolder.ps1
@@ -134,8 +134,9 @@ param (
     [Parameter(Mandatory=$False,HelpMessage="If specified, requests are directed to Office 365 endpoint (this overrides -EwsUrl)")]
     [switch]$Office365,
 
-    [Parameter(Mandatory=$False,HelpMessage="By default, script will specify Exchange 2010 (to work with 2010 and higher).  If using 2007, this switch must be specified.")]
-    [switch]$Exchange2007,
+    [Parameter(Mandatory=$False,HelpMessage="By default, script will specify Exchange 2010 (to work with 2010 and newer). to work with other versions of Exchange Specify the version Valid entries are 2007,2010,2013,2016.")]
+    [ValidateSet('2007','2010','2013','2016')]
+    [String]$ExchangeVersion,
 
     [Parameter(Mandatory=$False,HelpMessage="Path to managed API (if omitted, a search of standard paths is performed)")]
     [string]$EWSManagedApiPath = "",
@@ -1723,15 +1724,26 @@ function CreateService($smtpAddress)
     }
 
     # Create new service
-    if ($Exchange2007)
-    {
-        $exchangeService = New-Object Microsoft.Exchange.WebServices.Data.ExchangeService([Microsoft.Exchange.WebServices.Data.ExchangeVersion]::Exchange2007_SP1)
+    # Creates and returns an ExchangeService object to be used to access mailboxes
+    # Set Exchange Version based on user parm 
+    switch ($ExchangeVersion) {
+        2007 {$ExchangeVersion = "Exchange2007_SP1" }
+        2010 {$ExchangeVersion = "Exchange2010_SP2"  }
+        2013 {$ExchangeVersion = "Exchange2013_SP1" }
+        2016 {$ExchangeVersion = "Exchange2013_SP1" }
+        Default {$ExchangeVersion = "Exchange2010_SP2"}
     }
-    else
+    Log -Details "Connecting to Exchange Version:$ExchangeVersion" -Colour Yellow
+    # First of all check to see if we have a service object for this mailbox already
+    if ($script:services -eq $null)
     {
-        $exchangeService = New-Object Microsoft.Exchange.WebServices.Data.ExchangeService([Microsoft.Exchange.WebServices.Data.ExchangeVersion]::Exchange2010_SP2)
+        $script:services = @{}
     }
-
+    if ($script:services.ContainsKey($smtpAddress))
+    {
+        return $script:services[$smtpAddress]
+    }
+    
     # Do we need to use OAuth?
     if ($OAuth)
     {

--- a/Legacy/Merge-MailboxFolder.ps1
+++ b/Legacy/Merge-MailboxFolder.ps1
@@ -1730,19 +1730,12 @@ function CreateService($smtpAddress)
         2007 {$ExchangeVersion = "Exchange2007_SP1" }
         2010 {$ExchangeVersion = "Exchange2010_SP2"  }
         2013 {$ExchangeVersion = "Exchange2013_SP1" }
-        2016 {$ExchangeVersion = "Exchange2013_SP1" }
+        2016 {$ExchangeVersion = "Exchange2016" }
         Default {$ExchangeVersion = "Exchange2010_SP2"}
     }
     Log -Details "Connecting to Exchange Version:$ExchangeVersion" -Colour Yellow
-    # First of all check to see if we have a service object for this mailbox already
-    if ($script:services -eq $null)
-    {
-        $script:services = @{}
-    }
-    if ($script:services.ContainsKey($smtpAddress))
-    {
-        return $script:services[$smtpAddress]
-    }
+    #Create a new Exchange service
+    $exchangeService = New-Object Microsoft.Exchange.WebServices.Data.ExchangeService([Microsoft.Exchange.WebServices.Data.ExchangeVersion]::$ExchangeVersion)
     
     # Do we need to use OAuth?
     if ($OAuth)


### PR DESCRIPTION
I am slowly adding support for retention policy support for when you migrate an archive back into a users mailbox. Retention changed in 2013 and EWS needs to have a higher versions used to have access to those properties.  I updated this Parameter to be a little more flexible with specifying other version of Exchange.